### PR TITLE
Make attributes case-insensitive

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,12 +2,12 @@ package seedu.address.model.person;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -23,7 +23,7 @@ import seedu.address.model.person.attribute.StringAttribute;
 public class Person {
     private final UUID uuid;
     // Data fields
-    private final HashMap<String, Attribute> attributes = new HashMap<>();
+    private final TreeMap<String, Attribute> attributes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     /**
      * Constructs a person with a random UUID and a list of attributes.
@@ -286,7 +286,7 @@ public class Person {
     public Set<Attribute> getAttributes() {
         return new HashSet<>(attributes.values());
     }
-    public HashMap<String, Attribute> getAttributesMap() {
+    public TreeMap<String, Attribute> getAttributesMap() {
         return this.attributes;
     }
     public void setAttribute(String name, String str) {

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -16,6 +16,7 @@ import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -295,7 +296,7 @@ public class PersonTest {
         Person person = new Person(attributes);
 
         // Call getAttributesMap and check if it returns the correct attributes map
-        HashMap<String, Attribute> attributesMap = person.getAttributesMap();
+        TreeMap<String, Attribute> attributesMap = person.getAttributesMap();
         assertEquals(2, attributesMap.size());
         assertEquals(name, attributesMap.get("Name"));
         assertEquals(email, attributesMap.get("Email"));

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -15,7 +15,6 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.TreeMap;
 import java.util.UUID;
 


### PR DESCRIPTION
Any command that edits/deletes an attribute will work even if the case of the attribute name is different