### PR TITLE
Improve find command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -19,9 +19,9 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD_SHORT = "f";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " /alice /bob /charlie";
+            + "the specified key-phrases (case-insensitive) and displays them as a list.\n"
+            + "Parameters: /PHRASE [/MORE_PHRASES] ...\n"
+            + "Example: " + COMMAND_WORD + " /alice sim /bob /charlie";
 
     private final NameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -25,6 +25,10 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
+        if (!trimmedArgs.contains("/")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
 
         // Split by "/" to separate phrases
         String[] parts = trimmedArgs.split("/");

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -35,5 +35,11 @@ public class FindCommandParserTest {
     public void parse_empty_keywords() {
         assertParseFailure(parser, "/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
+    @Test
+    public void parse_keywordWithoutSlash() {
+        assertParseFailure(parser,
+                "Alice", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE)
+        );
+    }
 
 }


### PR DESCRIPTION
1. Improve find command message usage wording
2. Make command throw error with invalid input "find something" (instead of find /something)